### PR TITLE
Removes null check on body to allow tombstone messages

### DIFF
--- a/Topos/Serialization/TransportMessage.cs
+++ b/Topos/Serialization/TransportMessage.cs
@@ -12,7 +12,7 @@ namespace Topos.Serialization
         public TransportMessage(Dictionary<string, string> headers, byte[] body)
         {
             Headers = headers ?? throw new ArgumentNullException(nameof(headers));
-            Body = body ?? throw new ArgumentNullException(nameof(body));
+            Body = body;
         }
     }
 


### PR DESCRIPTION
Allow the property 'Body' of the class 'TransportMessage' to be null. This is needed to support tombstones/compaction (https://kafka.apache.org/documentation/#compaction).