### PR TITLE
adds postgresql position manager

### DIFF
--- a/Topos.PostgreSql.Tests/;
+++ b/Topos.PostgreSql.Tests/;
@@ -1,0 +1,20 @@
+using Npgsql;
+
+namespace Topos.PostgreSql.Tests
+{
+    public static class PostgreSqlTestConfig
+    {
+        public static void CleanDatabase(string connectionString)
+        {
+            using var connection = new NpgsqlConnection(connectionString);
+
+            connection.Open();
+
+            var clean = "DROP TABLE IF EXISTS topos.kafka_position; DROP SCHEMA IF EXISTS topos;";
+
+            using var cmd = new NpgsqlCommand(clean, connection);
+
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/Topos.PostgreSql.Tests/PostgreSqlFixtureBase.cs
+++ b/Topos.PostgreSql.Tests/PostgreSqlFixtureBase.cs
@@ -1,0 +1,9 @@
+using Topos.Tests;
+
+namespace Topos.PostgreSql.Tests
+{
+    public abstract class PostgreSqlFixtureBase : ToposFixtureBase
+    {
+        protected void CleanDatabase(string connectionString) => PostgreSqlTestConfig.CleanDatabase(connectionString);
+    }
+}

--- a/Topos.PostgreSql.Tests/PostgreSqlTestConfig.cs
+++ b/Topos.PostgreSql.Tests/PostgreSqlTestConfig.cs
@@ -1,0 +1,20 @@
+using Npgsql;
+
+namespace Topos.PostgreSql.Tests
+{
+    public static class PostgreSqlTestConfig
+    {
+        public static void CleanDatabase(string connectionString)
+        {
+            using var connection = new NpgsqlConnection(connectionString);
+
+            connection.Open();
+
+            var clean = "DROP TABLE IF EXISTS topos.kafka_position; DROP SCHEMA IF EXISTS topos;";
+
+            using var cmd = new NpgsqlCommand(clean, connection);
+
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/Topos.PostgreSql.Tests/PostgreSqlTestConfig.cs
+++ b/Topos.PostgreSql.Tests/PostgreSqlTestConfig.cs
@@ -10,7 +10,7 @@ namespace Topos.PostgreSql.Tests
 
             connection.Open();
 
-            var clean = "DROP TABLE IF EXISTS topos.kafka_position; DROP SCHEMA IF EXISTS topos;";
+            var clean = "DROP TABLE IF EXISTS topos.position_manager; DROP SCHEMA IF EXISTS topos;";
 
             using var cmd = new NpgsqlCommand(clean, connection);
 

--- a/Topos.PostgreSql.Tests/TestPostgreSqlPositionManager.cs
+++ b/Topos.PostgreSql.Tests/TestPostgreSqlPositionManager.cs
@@ -1,0 +1,64 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Topos.Consumer;
+
+namespace Topos.PostgreSql.Tests
+{
+    [TestFixture]
+    public class TestPostgreSqlPositionManager : PostgreSqlFixtureBase
+    {
+        PostgreSqlPositionManager _positionManager;
+
+        protected override void SetUp()
+        {
+            var connectionString = "Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=postgres";
+            CleanDatabase(connectionString);
+            _positionManager = new PostgreSqlPositionManager(connectionString, "my_consumer_group");
+        }
+
+        [Test]
+        public async Task CanSetPosition()
+        {
+            await _positionManager.Set(new Position("test-topic", 1, 100));
+            await _positionManager.Set(new Position("test-topic", 2, 100));
+            await _positionManager.Set(new Position("test-topic", 7, -1));
+            await _positionManager.Set(new Position("test-topic", 7, (long)int.MaxValue + 5));
+        }
+
+        [Test]
+        public async Task GetsNothingWhenAskingForPositionsInitially()
+        {
+            var position = await _positionManager.Get("test-topic", partition: 1);
+
+            Assert.That(position, Is.EqualTo(Position.Default("test-topic", partition: 1)));
+        }
+
+        [Test]
+        public async Task CanGetSinglePosition()
+        {
+            await _positionManager.Set(new Position("test-topic", 2, 100));
+
+            var position = await _positionManager.Get("test-topic", 2);
+
+            Assert.That(position, Is.Not.Null);
+
+            Assert.That(position.Partition, Is.EqualTo(2));
+            Assert.That(position.Offset, Is.EqualTo(100));
+        }
+
+        [Test]
+        public async Task CanGetUpdatedSinglePosition()
+        {
+            await _positionManager.Set(new Position("test-topic", 2, 100));
+            await _positionManager.Set(new Position("test-topic", 2, 101));
+            await _positionManager.Set(new Position("test-topic", 2, 110));
+
+            var position = await _positionManager.Get("test-topic", 2);
+
+            Assert.That(position, Is.Not.Null);
+
+            Assert.That(position.Partition, Is.EqualTo(2));
+            Assert.That(position.Offset, Is.EqualTo(110));
+        }
+    }
+}

--- a/Topos.PostgreSql.Tests/Topos.PostgreSql.Tests.csproj
+++ b/Topos.PostgreSql.Tests/Topos.PostgreSql.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Topos.PostgreSql\Topos.PostgreSql.csproj" />
+    <ProjectReference Include="..\Topos.Tests\Topos.Tests.csproj" />
+    <ProjectReference Include="..\Topos\Topos.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Topos.PostgreSql/Config/PostgreSqlPositionManagerConfigurationExtensions.cs
+++ b/Topos.PostgreSql/Config/PostgreSqlPositionManagerConfigurationExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using Topos.Consumer;
+using Topos.PostgreSql;
+
+namespace Topos.Config
+{
+    public static class PostgreSqlPositionManagerConfigurationExtension
+    {
+        public static void StoreInPostgreSql(
+            this StandardConfigurer<IPositionManager> configurer,
+            string connectionString,
+            string consumerGroup)
+        {
+            if (configurer is null)
+                throw new ArgumentNullException(nameof(configurer));
+            if (string.IsNullOrEmpty(connectionString))
+                throw new ArgumentException($"{nameof(connectionString)} cannot be null or empty.");
+            if (string.IsNullOrEmpty(consumerGroup))
+                throw new ArgumentException($"{nameof(consumerGroup)} cannot be null or empty.");
+
+            var registrar = StandardConfigurer.Open(configurer);
+            registrar.Register(c => new PostgreSqlPositionManager(connectionString, consumerGroup));
+        }
+    }
+}

--- a/Topos.PostgreSql/PostgreSql/PostgreSqlPositionManager.cs
+++ b/Topos.PostgreSql/PostgreSql/PostgreSqlPositionManager.cs
@@ -33,7 +33,7 @@ namespace Topos.PostgreSql
             await connection.OpenAsync();
 
             var query = @"
-              INSERT INTO topos.kafka_position (
+              INSERT INTO topos.position_manager (
                 consumer_group,
                 topic,
                 partition,
@@ -47,9 +47,9 @@ namespace Topos.PostgreSql
               UPDATE SET
                   position = @position
               WHERE
-                  topos.kafka_position.consumer_group = @consumer_group AND
-                  topos.kafka_position.topic = @topic AND
-                  topos.kafka_position.partition = @partition
+                  topos.position_manager.consumer_group = @consumer_group AND
+                  topos.position_manager.topic = @topic AND
+                  topos.position_manager.partition = @partition
             ";
 
             using var cmd = new NpgsqlCommand(query, connection);
@@ -75,7 +75,7 @@ namespace Topos.PostgreSql
 
             var getPositionQuery = @"
               SELECT position
-              FROM topos.kafka_position
+              FROM topos.position_manager
               WHERE
                     consumer_group = @consumer_group AND
                     topic = @topic AND
@@ -103,7 +103,7 @@ namespace Topos.PostgreSql
         {
             var schemaSetup = @"
                     CREATE SCHEMA topos;
-                    CREATE TABLE topos.kafka_position (
+                    CREATE TABLE topos.position_manager (
                         consumer_group varchar(255),
                         topic varchar(255),
                         partition integer,
@@ -115,7 +115,6 @@ namespace Topos.PostgreSql
             await connection.OpenAsync();
 
             using var transaction = await connection.BeginTransactionAsync();
-
             using var cmd = new NpgsqlCommand(schemaSetup, connection, transaction);
 
             var result = await cmd.ExecuteNonQueryAsync();

--- a/Topos.PostgreSql/PostgreSql/PostgreSqlPositionManager.cs
+++ b/Topos.PostgreSql/PostgreSql/PostgreSqlPositionManager.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading.Tasks;
+using Topos.Consumer;
+using Npgsql;
+using System.Collections.Generic;
+
+namespace Topos.PostgreSql
+{
+    public class PostgreSqlPositionManager : IPositionManager
+    {
+        private readonly string _connectionString;
+        private readonly string _consumerGroup;
+
+        public PostgreSqlPositionManager(
+            string connectionString,
+            string consumerGroup)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+                throw new ArgumentException($"{nameof(connectionString)} cannot be null or empty.");
+            if (string.IsNullOrEmpty(consumerGroup))
+                throw new ArgumentException($"{nameof(consumerGroup)} cannot be null or empty.");
+
+            _connectionString = connectionString;
+            _consumerGroup = consumerGroup;
+
+            if (!SchemaExist().Result)
+                InitSchema().Wait();
+        }
+
+        public async Task Set(Position position)
+        {
+            using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var query = @"
+              INSERT INTO topos.kafka_position (
+                consumer_group,
+                topic,
+                partition,
+                position)
+              VALUES (
+                @consumer_group,
+                @topic,
+                @partition,
+                @position)
+              ON CONFLICT(consumer_group, topic, partition) DO
+              UPDATE SET
+                  position = @position
+              WHERE
+                  topos.kafka_position.consumer_group = @consumer_group AND
+                  topos.kafka_position.topic = @topic AND
+                  topos.kafka_position.partition = @partition
+            ";
+
+            using var cmd = new NpgsqlCommand(query, connection);
+
+            cmd.Parameters.AddWithValue("@consumer_group", _consumerGroup);
+            cmd.Parameters.AddWithValue("@topic", position.Topic);
+            cmd.Parameters.AddWithValue("@partition", position.Partition);
+            cmd.Parameters.AddWithValue("@position", position.Offset);
+
+            var result = await cmd.ExecuteNonQueryAsync();
+
+            if (result == 0)
+            {
+                throw new Exception($@"Consumergroup: '{_consumerGroup}' with topic: '{position.Topic}'
+                                       and partition: '{position.Partition}' did not get updated.");
+            }
+        }
+
+        public async Task<Position> Get(string topic, int partition)
+        {
+            using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var getPositionQuery = @"
+              SELECT position
+              FROM topos.kafka_position
+              WHERE
+                    consumer_group = @consumer_group AND
+                    topic = @topic AND
+                    partition = @partition
+            ";
+
+            using var cmd = new NpgsqlCommand(getPositionQuery, connection);
+
+            cmd.Parameters.AddWithValue("@consumer_group", _consumerGroup);
+            cmd.Parameters.AddWithValue("@topic", topic);
+            cmd.Parameters.AddWithValue("@partition", partition);
+
+            var result = await cmd.ExecuteScalarAsync();
+
+            long position = default(long);
+            if (result is not null)
+                position = (long)result;
+
+            return EqualityComparer<long>.Default.Equals(position, default(long))
+                ? Position.Default(topic, partition)
+                : new Position(topic, partition, position);
+        }
+
+        private async Task InitSchema()
+        {
+            var schemaSetup = @"
+                    CREATE SCHEMA topos;
+                    CREATE TABLE topos.kafka_position (
+                        consumer_group varchar(255),
+                        topic varchar(255),
+                        partition integer,
+                        position bigint,
+                        PRIMARY KEY(consumer_group, topic, partition)
+                     );";
+
+            using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            using var transaction = await connection.BeginTransactionAsync();
+
+            using var cmd = new NpgsqlCommand(schemaSetup, connection, transaction);
+
+            var result = await cmd.ExecuteNonQueryAsync();
+            if (result == 0)
+            {
+                await transaction.RollbackAsync();
+                throw new Exception("Failed setting up schema and table");
+            }
+            else
+            {
+                await transaction.CommitAsync();
+            }
+        }
+
+        private async Task<bool> SchemaExist()
+        {
+            var schemaExistsQuery =
+                "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'topos'";
+
+            using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            using var cmd = new NpgsqlCommand(schemaExistsQuery, connection);
+
+            var result = await cmd.ExecuteScalarAsync();
+
+            return result is not null;
+        }
+    }
+}

--- a/Topos.PostgreSql/Topos.PostgreSql.csproj
+++ b/Topos.PostgreSql/Topos.PostgreSql.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="npgsql" Version="5.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Topos\Topos.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Topos.sln
+++ b/Topos.sln
@@ -61,6 +61,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topos.SystemTextJson", "Top
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topos.SystemTextJson.Tests", "Topos.SystemTextJson.Tests\Topos.SystemTextJson.Tests.csproj", "{5C74171A-8A86-4E1F-803A-74F7E811FBA2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topos.PostgreSql", "Topos.PostgreSql\Topos.PostgreSql.csproj", "{17AC8EF1-FCCA-40F4-910D-B358B35A0EAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topos.PostgreSql.Tests", "Topos.PostgreSql.Tests\Topos.PostgreSql.Tests.csproj", "{0F8E21BF-FF3D-4D56-AA2E-BCAF56D25012}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +143,14 @@ Global
 		{5C74171A-8A86-4E1F-803A-74F7E811FBA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C74171A-8A86-4E1F-803A-74F7E811FBA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C74171A-8A86-4E1F-803A-74F7E811FBA2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17AC8EF1-FCCA-40F4-910D-B358B35A0EAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17AC8EF1-FCCA-40F4-910D-B358B35A0EAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17AC8EF1-FCCA-40F4-910D-B358B35A0EAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17AC8EF1-FCCA-40F4-910D-B358B35A0EAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F8E21BF-FF3D-4D56-AA2E-BCAF56D25012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8E21BF-FF3D-4D56-AA2E-BCAF56D25012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F8E21BF-FF3D-4D56-AA2E-BCAF56D25012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F8E21BF-FF3D-4D56-AA2E-BCAF56D25012}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds PostgreSql position manager. The solution creates a table named `kafka_position` inside of the schema `topos`. It has an composite primary key based on `consumer_group`, `topic` and `partition`. I decided not to use an approach where the schema and table name is defined by the user, since that implementation was not optimal after working on it a bit. If you have any better suggestion to the name of the `schema` and `table` please say so and I'll make a new commit with the updated names. 

The flow is as follows:
* If the schema does not exist the manager creates it. It does this by checking if the schema exists, if it does it will not do anything otherwise it will create the `schema` and the `table`.
* On `GET` we will return the `DefaultPosition` like it is done in the MongoDB implementation otherwise we return the position queried from the database.
* On `SET` we will `upsert` the table, so if a position with the composite key already exist we update the position otherwise we insert a new row with the composite key and the newest position. 

The implementation is based on the `MongoDbPositionsManagerConfigurationExtensions` and followed the same structure for the unit tests.